### PR TITLE
Enable concurrent subset conversions with shared worker pool

### DIFF
--- a/batch_to_mds.py
+++ b/batch_to_mds.py
@@ -1,9 +1,15 @@
 #!/usr/bin/env python3
 # pip install datasets huggingface_hub
-import os, re, shutil, subprocess, sys, time
+import os, re, shutil, sys, asyncio
 from argparse import ArgumentParser
-from typing import List
-from datasets import get_dataset_config_names, get_dataset_split_names
+from dataclasses import dataclass
+from typing import Dict, List, Optional
+from contextlib import asynccontextmanager
+from datasets import (
+    get_dataset_config_names,
+    get_dataset_split_names,
+    get_dataset_config_info,
+)
 from huggingface_hub import HfApi
 
 
@@ -19,10 +25,31 @@ def hub_has_index(api: HfApi, repo_id: str, cfg: str, split: str) -> bool:
         return False
 
 
-def run(cmd: List[str]) -> int:
-    print(" ".join(cmd), flush=True)
-    p = subprocess.run(cmd)
-    return p.returncode
+@dataclass
+class Job:
+    cfg: str
+    split: str
+    procs: int
+    size: Optional[int]
+
+
+class ProcLimiter:
+    def __init__(self, total: int):
+        self.total = total
+        self._avail = total
+        self._cond = asyncio.Condition()
+
+    @asynccontextmanager
+    async def limit(self, n: int):
+        async with self._cond:
+            await self._cond.wait_for(lambda: self._avail >= n)
+            self._avail -= n
+        try:
+            yield
+        finally:
+            async with self._cond:
+                self._avail += n
+                self._cond.notify_all()
 
 
 def main():
@@ -44,7 +71,13 @@ def main():
         help="Path to the converter script you put in the canvas",
     )
     ap.add_argument(
-        "--procs", type=int, default=16, help="# workers passed to converter"
+        "--procs", type=int, default=16, help="# workers for largest subsets"
+    )
+    ap.add_argument(
+        "--total-procs",
+        type=int,
+        default=None,
+        help="Total worker processes to share across jobs (default: --procs)",
     )
     ap.add_argument(
         "--hash", default="xxh64", help="xxh64 | sha1 | none (passed to converter)"
@@ -82,14 +115,27 @@ def main():
     api = HfApi()
     os.makedirs(args.out_local, exist_ok=True)
 
+    if args.total_procs is None:
+        args.total_procs = args.procs
+
     # Enumerate configs (subsets)
     cfgs = get_dataset_config_names(args.src)
     inc_cfg, exc_cfg = re.compile(args.include_config), re.compile(args.exclude_config)
     cfgs = [c for c in cfgs if inc_cfg.search(str(c)) and not exc_cfg.search(str(c))]
     print(f"Found {len(cfgs)} configs after filtering.")
 
-    # Helper to build converter cmd
-    def converter_cmd(cfg: str, split: str) -> List[str]:
+    def determine_procs(num_examples: Optional[int]) -> int:
+        if num_examples is None:
+            return 1
+        if num_examples < 1_000_000:
+            return 1
+        if num_examples < 5_000_000:
+            return min(2, args.procs)
+        if num_examples < 20_000_000:
+            return min(4, args.procs)
+        return args.procs
+
+    def converter_cmd(cfg: str, split: str, procs: int) -> List[str]:
         cmd = [
             sys.executable,
             args.converter,
@@ -104,9 +150,9 @@ def main():
             "--out-hub",
             args.out_hub,
             "--dest-subdir",
-            cfg,  # mirror config name
+            cfg,
             "--procs",
-            str(args.procs),
+            str(procs),
             "--streaming",
             "--upload-after",
             "--hash",
@@ -121,9 +167,10 @@ def main():
             ]
         return cmd
 
-    total_jobs = 0
+    jobs: List[Job] = []
+    pending_cfg_counts: Dict[str, int] = {}
+
     for cfg in cfgs:
-        # Enumerate splits for this config
         try:
             splits = get_dataset_split_names(args.src, cfg)
         except Exception as e:
@@ -134,50 +181,57 @@ def main():
         splits = [s for s in splits if inc_sp.search(s) and not exc_sp.search(s)]
         if not splits:
             continue
+        pending_cfg_counts[cfg] = len(splits)
+
+        info = None
+        try:
+            info = get_dataset_config_info(args.src, cfg)
+        except Exception:
+            pass
 
         for split in splits:
-            total_jobs += 1
-            print(f"\n=== {args.src} | {cfg} | {split} ===")
-            if not args.force and hub_has_index(api, args.out_hub, cfg, split):
-                print("✓ Skip — already on Hub.")
-                continue
+            size = None
+            if info and info.splits and split in info.splits:
+                size = info.splits[split].num_examples
+            procs = determine_procs(size)
+            jobs.append(Job(cfg, split, procs, size))
 
-            cmd = converter_cmd(cfg, split)
-            if args.dry_run:
-                print("DRY RUN:", " ".join(cmd))
-                continue
+    limiter = ProcLimiter(args.total_procs)
 
-            rc = run(cmd)
-            if rc != 0:
-                print(f"✗ Failed ({rc}). Keeping local files for inspection.")
-                continue
+    async def run_job(job: Job):
+        cfg, split, procs, size = job.cfg, job.split, job.procs, job.size
+        print(f"\n=== {args.src} | {cfg} | {split} (procs={procs}) ===")
+        if not args.force and hub_has_index(api, args.out_hub, cfg, split):
+            print("✓ Skip — already on Hub.")
+            return
+        cmd = converter_cmd(cfg, split, procs)
+        if args.dry_run:
+            print("DRY RUN:", " ".join(cmd))
+            return
+        async with limiter.limit(procs):
+            print(" ".join(cmd), flush=True)
+            proc = await asyncio.create_subprocess_exec(*cmd)
+            rc = await proc.wait()
+        if rc != 0:
+            print(f"✗ Failed ({rc}). Keeping local files for inspection.")
+            return
+        if not args.no_delete and hub_has_index(api, args.out_hub, cfg, split):
+            pending_cfg_counts[cfg] -= 1
+            if pending_cfg_counts[cfg] == 0:
+                local_cfg_dir = os.path.join(args.out_local, cfg)
+                try:
+                    shutil.rmtree(local_cfg_dir)
+                    print(f"🧹 Deleted local {local_cfg_dir}")
+                except Exception as e:
+                    print(f"Warning: could not delete {local_cfg_dir}: {e}")
+        await asyncio.sleep(args.sleep)
 
-            # Verify upload then delete local artifacts for this cfg/split
-            # if hub_has_index(api, args.out_hub, cfg, split):
-            if True:
-                if not args.no_delete:
-                    local_dir = os.path.join(
-                        args.out_local,
-                        cfg,
-                        split.rsplit("/", 1)[0] if "/" in split else "",
-                        split,
-                    )
-                    # More robust: nuke the whole config directory for this run
-                    local_cfg_dir = os.path.join(args.out_local, cfg)
-                    target = (
-                        local_cfg_dir if os.path.isdir(local_cfg_dir) else local_dir
-                    )
-                    try:
-                        shutil.rmtree(target)
-                        print(f"🧹 Deleted local {target}")
-                    except Exception as e:
-                        print(f"Warning: could not delete {target}: {e}")
-            else:
-                print("Warning: index.json not found on Hub; not deleting local copy.")
+    async def runner():
+        await asyncio.gather(*(run_job(j) for j in jobs))
 
-            time.sleep(args.sleep)
+    asyncio.run(runner())
 
-    print(f"\nDone. Processed {total_jobs} job(s).")
+    print(f"\nDone. Processed {len(jobs)} job(s).")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- allow multiple config/split conversions to run in parallel
- share a global process pool and scale workers per subset size

## Testing
- `python -m py_compile batch_to_mds.py`
- `python -m py_compile hf_to_mds_streaming.py`


------
https://chatgpt.com/codex/tasks/task_e_68a8ab9dd278832bac418a602e5dffea