### PR TITLE
feat: run subset conversions concurrently

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ python hf_to_mds_streaming.py \
 **`batch_to_mds.py`** - Batch convert all configs/splits:
 
 - `--src` / `--out-hub`: Source and destination repos (required)
-- `--procs`: Worker processes (default: 16)
+- `--procs`: Total worker processes across all subsets; jobs run concurrently (default: 16)
+- `--records-per-proc`: Approximate records per worker when sizing each job (default: 1,000,000)
 - `--compression`: e.g., `zstd`, `zstd:11`
 - `--include-config` / `--exclude-config`: Regex filters
 - `--dry-run`: Preview without executing


### PR DESCRIPTION
## Summary
- allow `batch_to_mds.py` to schedule conversions for multiple config/split pairs at once
- size each job with `--records-per-proc` and reuse idle workers across subsets
- document new concurrency options in README

## Testing
- `python -m py_compile batch_to_mds.py hf_to_mds_streaming.py`
- `python batch_to_mds.py --help`

------
https://chatgpt.com/codex/tasks/task_e_68a8ab9dd278832bac418a602e5dffea